### PR TITLE
Stop authentication if proxy doesn't want one 

### DIFF
--- a/proxysetup/ntlm/ntlm.go
+++ b/proxysetup/ntlm/ntlm.go
@@ -47,6 +47,11 @@ func ProxySetup(conn net.Conn, targetAddr string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode == 200 {
+		return nil
+	}
 	_, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err


### PR DESCRIPTION
If the proxy doesn't require authentication for all domains (and returns HTTP 200 on first try, ReadAll(resp.Body) hangs until the timeout hits (because ContentLength is -1 case of our proxy).

Fixed this by stopping authentication if 200 is returned.